### PR TITLE
Prevent Formater from changing a 0 ind to ' '

### DIFF
--- a/lib/MARC/Moose/Formater/Legacy.pm
+++ b/lib/MARC/Moose/Formater/Legacy.pm
@@ -29,8 +29,8 @@ override 'format' => sub {
             }
             $nfield = MARC::Field->new(
                 $field->tag,
-                $field->ind1 || ' ',
-                $field->ind2 || ' ', @sf ) if @sf;
+                (defined $field->ind1 ) ? $field->ind1 : ' ',
+                (defined $field->ind2 ) ? $field->ind2 : ' ', @sf ) if @sf;
         }
         $marc->append_fields($nfield) if $nfield;
     }


### PR DESCRIPTION
I'm not sure this is the write way to do it, anyway, there is something to do to preserve the '0' indicator which is legit :).